### PR TITLE
Fix lint warnings causing Netlify build failure

### DIFF
--- a/src/Components/Header.jsx
+++ b/src/Components/Header.jsx
@@ -3,18 +3,16 @@ import { NavLink } from "react-router-dom";
 
 // HEADER COMPONENT
 export default function Header({ selectedTweet }) {
-  {
-    return selectedTweet ? (
-      <div className="header">
-        <NavLink to="/home">
-          <i className="fa-solid fa-left-long"></i>
-        </NavLink>
-        <h3>Tweet</h3>
-      </div>
-    ) : (
-      <div className="header">
-        <h3>Home</h3>
-      </div>
-    );
-  }
+  return selectedTweet ? (
+    <div className="header">
+      <NavLink to="/home">
+        <i className="fa-solid fa-left-long"></i>
+      </NavLink>
+      <h3>Tweet</h3>
+    </div>
+  ) : (
+    <div className="header">
+      <h3>Home</h3>
+    </div>
+  );
 }

--- a/src/Components/OriginalTweet.jsx
+++ b/src/Components/OriginalTweet.jsx
@@ -6,13 +6,12 @@ export default function OriginalTweet({ tweetData }) {
   let likedTweets = localStorage.getItem("likedTweets");
   let likedTweetsArray = likedTweets ? JSON.parse(likedTweets) : [];
 
-   useEffect(() => {
-
+  useEffect(() => {
     likedTweetsArray.forEach((id) => {
-        if (tweetData._id === id) setLiked(true);
-        console.log(id)
-      });
-   }, []);
+      if (tweetData._id === id) setLiked(true);
+      console.log(id);
+    });
+  }, [likedTweetsArray, tweetData._id]);
 
   // STORING TWEET IN LOCALSTORAGE ON LIKING ORIGINAL TWEET
 

--- a/src/Components/Timeline.jsx
+++ b/src/Components/Timeline.jsx
@@ -8,7 +8,7 @@ export default function Timeline({tweets,selectTweet,clearTweet}) {
 
   useEffect(() => {
     clearTweet();
-  },[])
+  }, [clearTweet]);
 
   return (
     <div className="timeline">

--- a/src/Components/Tweet.jsx
+++ b/src/Components/Tweet.jsx
@@ -8,7 +8,7 @@ export default function Tweet({ tweetData, selectTweet, likedTweetsArray }) {
     likedTweetsArray.forEach((id) => {
       if (tweetData._id === id) setLiked(true);
     });
-  }, []);
+  }, [likedTweetsArray, tweetData._id]);
 
   // STORING TWEET IN LOCALSTORAGE ON LIKING ORIGINAL TWEET
 


### PR DESCRIPTION
## Summary
- fix redundant block in `Header` component
- fix missing dependencies in `OriginalTweet`, `Tweet`, and `Timeline`
- install dependencies and run tests (none present)

## Testing
- `npm test -- --watchAll=false --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_6870cc7f6434832caa82b21d2064f6f5